### PR TITLE
fix: Add debug logging to Telegram callback handler

### DIFF
--- a/src/notifiers/telegram_notifier.py
+++ b/src/notifiers/telegram_notifier.py
@@ -106,8 +106,10 @@ class InteractiveTelegramBot(BaseNotifier):
     async def _main_button_callback(self, update: Update, context: ContextTypes.DEFAULT_TYPE):
         query = update.callback_query
         await query.answer()
-        # ... (button logic for start/stop/menu remains the same)
         callback_data = query.data
+        logger.info(f"DEBUG: Received callback_data: '{callback_data}'") # DEBUG LOGGING
+
+        # ... (button logic for start/stop/menu remains the same)
         if callback_data.startswith("analyze_"):
             parts = callback_data.split("_")
             analysis_scope = parts[1]


### PR DESCRIPTION
Adds a logging statement to the `_main_button_callback` function in the `InteractiveTelegramBot` class. This is intended to help diagnose an issue where the incorrect handler is being triggered by a button press. The log will show the exact `callback_data` being received from the Telegram API.