### PR TITLE
This commit fixes a `NameError` in `src/notifiers/telegram_notifier.p…

### DIFF
--- a/src/notifiers/telegram_notifier.py
+++ b/src/notifiers/telegram_notifier.py
@@ -3,7 +3,7 @@ import re
 import time
 import anyio
 import asyncio
-from typing import Dict, Any
+from typing import Dict, Any, List
 import pandas as pd
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup


### PR DESCRIPTION
…y` by adding the missing import for `List` from the `typing` module.