### PR TITLE
fix: Resolve NameError for BaseNotifier

### DIFF
--- a/src/notifiers/telegram_notifier.py
+++ b/src/notifiers/telegram_notifier.py
@@ -10,6 +10,7 @@ from telegram.ext import Application, CommandHandler, CallbackQueryHandler, Cont
 from telegram.constants import ParseMode
 
 # --- New Imports ---
+from .base_notifier import BaseNotifier
 from src.analysis.models import AnalysisReport, TimeframeAnalysis, TechnicalPattern, Support, Resistance, ExecutiveSummary, ConfirmedTrade
 from src.analysis.tracker import AnalysisTracker
 from src.notifiers.analysis_formatter import format_full_analysis_messages


### PR DESCRIPTION
This commit fixes a `NameError: name 'BaseNotifier' is not defined` that occurred when starting the application.

The error was caused by a missing import in `src/notifiers/telegram_notifier.py`. The `InteractiveTelegramBot` class inherits from `BaseNotifier`, but the corresponding import statement was missing after a major refactoring.

This has been resolved by adding the line `from .base_notifier import BaseNotifier` to the file.