### PR TITLE
fix: Implement abstract method 'send' in InteractiveTelegramBot

### DIFF
--- a/src/notifiers/telegram_notifier.py
+++ b/src/notifiers/telegram_notifier.py
@@ -42,6 +42,18 @@ class InteractiveTelegramBot(BaseNotifier):
         # Use the new AnalysisTracker
         self.tracker = AnalysisTracker()
 
+    def send(self, message: str, parse_mode: str = 'HTML') -> bool:
+        """
+        Implementation of the abstract 'send' method.
+        This bot is interactive, so this method is a placeholder.
+        The main functionality is started via the `start()` method.
+        """
+        logger.warning(
+            "The `send` method was called on the interactive bot, but it's not designed for direct sending. "
+            "Use `start()` to run the bot."
+        )
+        return False
+
     # --- Keyboard Layouts (Refactored) ---
     def _get_start_message_text(self) -> str:
         status = "🟢 متصل وجاهز للعمل" if self.bot_state["is_active"] else "🔴 متوقف"


### PR DESCRIPTION
This commit resolves a `TypeError` that prevented the application from starting. The error occurred because the `InteractiveTelegramBot` class did not implement the abstract method `send` inherited from its parent class, `BaseNotifier`.

The `send` method was likely removed by mistake during a major refactoring.

This has been fixed by adding the required `send` method to the `InteractiveTelegramBot` class. The implementation is a placeholder that logs a warning, as this interactive bot is not intended to be used for direct, non-interactive message sending. This change satisfies the abstract class contract and allows the bot to be instantiated correctly.