### PR TITLE
fix: Add missing 'List' import from typing module

### DIFF
--- a/src/notifiers/telegram_notifier.py
+++ b/src/notifiers/telegram_notifier.py
@@ -2,7 +2,7 @@ import logging
 import re
 import asyncio
 import uuid
-from typing import Dict, Any
+from typing import Dict, Any, List
 from pathlib import Path
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup


### PR DESCRIPTION
This commit resolves a `NameError: name 'List' is not defined` that occurred when starting the application.

The error was caused by using the `List` type hint in the signature of the `_create_mock_analysis` method in `src/notifiers/telegram_notifier.py` without importing it from the `typing` module.

This fix adds `List` to the existing `typing` import statement at the top of the file, resolving the `NameError` and allowing the application to start correctly.