### PR TITLE
feat: Improve test coverage from 67% to 75%

### DIFF
--- a/tests/test_new_support_resistance.py
+++ b/tests/test_new_support_resistance.py
@@ -1,0 +1,60 @@
+import unittest
+import pandas as pd
+import numpy as np
+from src.analysis.new_support_resistance import find_new_support_resistance
+from src.analysis.data_models import Level
+
+class TestNewSupportResistance(unittest.TestCase):
+
+    def setUp(self):
+        # Sample data that should generate some peaks
+        data = {
+            'high': [100, 105, 102, 110, 108, 115, 112, 120, 118, 125, 122, 130, 128, 120, 110],
+            'low': [90, 95, 92, 100, 98, 105, 102, 110, 108, 115, 112, 120, 118, 115, 100],
+            'close': [95, 102, 98, 108, 105, 112, 110, 118, 115, 122, 120, 128, 125, 118, 105]
+        }
+        self.df = pd.DataFrame(data)
+
+    def test_find_new_support_resistance_valid_data(self):
+        result = find_new_support_resistance(self.df)
+        self.assertIn('supports', result)
+        self.assertIn('resistances', result)
+        self.assertIsInstance(result['supports'], list)
+        self.assertIsInstance(result['resistances'], list)
+        self.assertGreater(len(result['supports']), 0)
+        self.assertGreater(len(result['resistances']), 0)
+        self.assertIsInstance(result['supports'][0], Level)
+        self.assertIsInstance(result['resistances'][0], Level)
+
+    def test_find_new_support_resistance_empty_df(self):
+        df = pd.DataFrame()
+        result = find_new_support_resistance(df)
+        self.assertEqual(result, {'supports': [], 'resistances': []})
+
+    def test_find_new_support_resistance_zero_price_range(self):
+        data = {
+            'high': [100, 100, 100, 100],
+            'low': [100, 100, 100, 100],
+            'close': [100, 100, 100, 100]
+        }
+        df = pd.DataFrame(data)
+        result = find_new_support_resistance(df)
+        self.assertEqual(result, {'supports': [], 'resistances': []})
+
+    def test_find_new_support_resistance_no_peaks(self):
+        # Linearly increasing data should not have peaks
+        data = {
+            'high': np.arange(100, 120),
+            'low': np.arange(90, 110),
+            'close': np.arange(95, 115)
+        }
+        df = pd.DataFrame(data)
+        result = find_new_support_resistance(df)
+        # Should still have historical high/low
+        self.assertEqual(len(result['supports']), 1)
+        self.assertEqual(len(result['resistances']), 1)
+        self.assertEqual(result['supports'][0].name, 'دعم تاريخي')
+        self.assertEqual(result['resistances'][0].name, 'مقاومة تاريخية')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pattern_helpers.py
+++ b/tests/test_pattern_helpers.py
@@ -1,0 +1,54 @@
+import unittest
+import pandas as pd
+import numpy as np
+from src.analysis.patterns.pattern_helpers import calculate_dynamic_confidence, find_trend_line
+
+class TestPatternHelpers(unittest.TestCase):
+
+    def setUp(self):
+        self.config = {'ADX_PERIOD': 14, 'RSI_PERIOD': 14}
+        data = {
+            'volume': [1000, 1500, 1200, 2500, 1800] * 5,
+            'ADX_14': [20, 22, 28, 30, 26] * 5,
+            'RSI_14': [60, 65, 72, 78, 68] * 5
+        }
+        self.df = pd.DataFrame(data)
+
+    def test_calculate_dynamic_confidence_empty_df(self):
+        df = pd.DataFrame()
+        confidence = calculate_dynamic_confidence(df, self.config, 50, True)
+        self.assertEqual(confidence, 50)
+
+    def test_calculate_dynamic_confidence_bullish(self):
+        # Make the last volume high enough for bonus
+        self.df.loc[self.df.index[-1], 'volume'] = self.df['volume'].mean() * 2
+        confidence = calculate_dynamic_confidence(self.df, self.config, 50, True)
+        # 50 (base) + 10 (volume) + 10 (ADX > 25) + 5 (RSI < 75) = 75
+        self.assertEqual(confidence, 75)
+
+    def test_calculate_dynamic_confidence_bearish(self):
+        self.df.loc[self.df.index[-1], 'RSI_14'] = 30
+        confidence = calculate_dynamic_confidence(self.df, self.config, 60, False)
+        # 60 (base) + 0 (volume) + 10 (ADX > 25) + 5 (RSI > 25) = 75
+        self.assertEqual(confidence, 75)
+
+    def test_calculate_dynamic_confidence_capped(self):
+        confidence = calculate_dynamic_confidence(self.df, self.config, 90, True)
+        # 90 (base) + 0 (volume) + 10 (ADX > 25) + 5 (RSI < 75) = 105, capped at 98
+        self.assertEqual(confidence, 98)
+
+    def test_find_trend_line_valid(self):
+        x = [1, 2, 3, 4, 5]
+        y = [2, 4, 6, 8, 10] # y = 2x
+        line = find_trend_line(x, y)
+        self.assertAlmostEqual(line['slope'], 2.0)
+        self.assertAlmostEqual(line['intercept'], 0.0)
+
+    def test_find_trend_line_invalid_input(self):
+        line = find_trend_line([], [])
+        self.assertEqual(line, {'slope': 0, 'intercept': 0})
+        line = find_trend_line([1, 2], [1])
+        self.assertEqual(line, {'slope': 0, 'intercept': 0})
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_trade_management.py
+++ b/tests/test_trade_management.py
@@ -1,0 +1,125 @@
+import unittest
+import pandas as pd
+from src.trade_management import TradeManagement
+
+class TestTradeManagement(unittest.TestCase):
+    def setUp(self):
+        data = {
+            'high': [110, 112, 108, 115, 118],
+            'low': [100, 105, 102, 106, 110],
+            'close': [105, 110, 106, 112, 116]
+        }
+        self.df = pd.DataFrame(data)
+        self.trade_manager = TradeManagement(self.df, account_balance=10000, max_risk_per_trade=0.02)
+
+    def test_initialization(self):
+        self.assertIsNotNone(self.trade_manager)
+        self.assertEqual(self.trade_manager.account_balance, 10000)
+        self.assertEqual(self.trade_manager.max_risk_per_trade, 0.02)
+        self.assertEqual(self.trade_manager.current_price, 116)
+
+    def test_calculate_position_size_valid(self):
+        position_info = self.trade_manager.calculate_position_size(entry_price=116, stop_loss=110)
+        self.assertAlmostEqual(position_info['position_size'], 33.333, places=3)
+        self.assertAlmostEqual(position_info['total_value'], 3866.667, places=3)
+        self.assertEqual(position_info['risk_per_share'], 6)
+        self.assertAlmostEqual(position_info['risk_percentage'], 5.172, places=3)
+
+    def test_calculate_position_size_zero_distance(self):
+        position_info = self.trade_manager.calculate_position_size(entry_price=116, stop_loss=116)
+        self.assertIn('error', position_info)
+        self.assertEqual(position_info['error'], 'وقف الخسارة لا يمكن أن يكون نفس سعر الدخول')
+
+    def test_calculate_position_size_exceeds_balance(self):
+        # High risk to force total_value > account_balance
+        self.trade_manager.max_risk_per_trade = 0.5
+        position_info = self.trade_manager.calculate_position_size(entry_price=116, stop_loss=115)
+        self.assertAlmostEqual(position_info['position_size'], 86.207, places=3)
+        self.assertEqual(position_info['total_value'], 10000)
+
+    def test_get_trade_levels_with_sr(self):
+        analysis_results = {
+            'support_resistance': {
+                'nearest_support': {'price': 108},
+                'nearest_resistance': {'price': 120}
+            }
+        }
+        levels = self.trade_manager.get_trade_levels(analysis_results)
+        self.assertEqual(levels['long_entry'], 116)
+        self.assertEqual(levels['long_stop_loss'], 98)
+        self.assertEqual(levels['long_profit_target'], 143)
+        self.assertEqual(levels['short_entry'], 116)
+        self.assertEqual(levels['short_stop_loss'], 134)
+        self.assertEqual(levels['short_profit_target'], 89)
+
+    def test_get_trade_levels_no_sr(self):
+        analysis_results = {}
+        levels = self.trade_manager.get_trade_levels(analysis_results)
+        self.assertEqual(levels['long_entry'], 116)
+        self.assertEqual(levels['long_stop_loss'], 98)
+        self.assertEqual(levels['long_profit_target'], 143.0)
+        self.assertEqual(levels['short_entry'], 116)
+        self.assertEqual(levels['short_stop_loss'], 134)
+        self.assertEqual(levels['short_profit_target'], 89.0)
+
+    def test_get_comprehensive_trade_plan_buy_signal(self):
+        final_recommendation = {'main_action': 'شراء قوي'}
+        analysis_results = {}
+        trade_plan = self.trade_manager.get_comprehensive_trade_plan(final_recommendation, analysis_results)
+        self.assertEqual(trade_plan['signal'], 'شراء قوي')
+        self.assertEqual(trade_plan['direction'], 'Long')
+        self.assertEqual(trade_plan['entry_price'], 116)
+
+    def test_get_comprehensive_trade_plan_sell_signal(self):
+        final_recommendation = {'main_action': 'بيع قوي'}
+        analysis_results = {}
+        trade_plan = self.trade_manager.get_comprehensive_trade_plan(final_recommendation, analysis_results)
+        self.assertEqual(trade_plan['signal'], 'بيع قوي')
+        self.assertEqual(trade_plan['direction'], 'Short')
+        self.assertEqual(trade_plan['entry_price'], 116)
+
+    def test_get_comprehensive_trade_plan_wait_signal(self):
+        final_recommendation = {'main_action': 'انتظار'}
+        analysis_results = {}
+        trade_plan = self.trade_manager.get_comprehensive_trade_plan(final_recommendation, analysis_results)
+        self.assertEqual(trade_plan['signal'], 'انتظار')
+        self.assertEqual(trade_plan['recommendation'], "لا توجد صفقة حالياً. مراقبة السوق.")
+
+    def test_get_comprehensive_trade_plan_wait_signal_bullish_pattern(self):
+        final_recommendation = {'main_action': 'انتظار'}
+        analysis_results = {
+            'patterns': {
+                'found_patterns': [{
+                    'name': 'Bullish Pattern',
+                    'status': 'قيد التكوين',
+                    'is_bullish': True,
+                    'resistance_line': 120,
+                    'support_line': 110,
+                    'calculated_target': 130
+                }]
+            }
+        }
+        trade_plan = self.trade_manager.get_comprehensive_trade_plan(final_recommendation, analysis_results)
+        self.assertEqual(trade_plan['trade_idea_name'], 'مراقبة اختراق نمط Bullish Pattern')
+        self.assertEqual(trade_plan['conditional_entry'], 120)
+
+    def test_get_comprehensive_trade_plan_wait_signal_bearish_pattern(self):
+        final_recommendation = {'main_action': 'انتظار'}
+        analysis_results = {
+            'patterns': {
+                'found_patterns': [{
+                    'name': 'Bearish Pattern',
+                    'status': 'قيد التكوين',
+                    'is_bullish': False,
+                    'resistance_line': 120,
+                    'support_line': 110,
+                    'calculated_target': 100
+                }]
+            }
+        }
+        trade_plan = self.trade_manager.get_comprehensive_trade_plan(final_recommendation, analysis_results)
+        self.assertEqual(trade_plan['trade_idea_name'], 'مراقبة كسر نمط Bearish Pattern')
+        self.assertEqual(trade_plan['conditional_entry'], 110)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit introduces new tests for modules with low or no test coverage, significantly improving the overall test coverage of the repository from 67% to 75%.

The following modules, which previously had 0% coverage, are now tested:
- `src/trade_management.py` (now 100% coverage)
- `src/analysis/new_support_resistance.py` (now 68% coverage)
- `src/analysis/patterns/pattern_helpers.py` (now 84% coverage)

The new tests cover various scenarios, including valid inputs, edge cases, and different logical paths, ensuring the robustness of the new test suites. All new and existing tests pass successfully.