### PR TITLE
fix(validators): Make timeframe validation case-insensitive

### DIFF
--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -34,5 +34,5 @@ def validate_symbol_timeframe(symbol: str, timeframe: str):
 
     supported_for_symbol = SUPPORTED_COMBINATIONS[okx_symbol]
 
-    if timeframe not in supported_for_symbol:
+    if timeframe.lower() not in supported_for_symbol:
         raise ValueError(f"Timeframe {timeframe} is not supported for {symbol} on OKX.")

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -47,3 +47,13 @@ def test_validate_symbol_timeframe_defaults_to_eth_for_unknown_symbol_bug():
     # After the fix, it SHOULD raise a ValueError.
     with pytest.raises(ValueError, match=f"Symbol {unknown_symbol} is not supported."):
         validate_symbol_timeframe(unknown_symbol, timeframe_supported_by_eth)
+
+def test_validate_symbol_timeframe_supported_uppercase():
+    """
+    Tests that the function passes for a supported symbol and an uppercase timeframe.
+    This test will fail before the fix is applied.
+    """
+    symbol = 'BTC/USDT'
+    timeframe = '1H'
+    # This should not raise any exception after the fix
+    validate_symbol_timeframe(symbol, timeframe)


### PR DESCRIPTION
The `validate_symbol_timeframe` function was previously case-sensitive when validating timeframes. This would cause a `ValueError` to be raised for valid timeframes that were provided in uppercase (e.g., '1H').

This commit fixes the issue by converting the input timeframe to lowercase before performing the validation. A new test case has been added to verify that uppercase timeframes are now correctly handled.