### PR TITLE
Refactor: Overhaul analysis report format

### DIFF
--- a/unsupported_analysis_fields.txt
+++ b/unsupported_analysis_fields.txt
@@ -1,0 +1,6 @@
+The following fields from the requested template are not currently supported by the bot's analysis engine because they represent price ZONES rather than specific price LEVELS, or require specific historical analysis that is not yet implemented:
+
+1.  منطقة طلب عالية (High Demand Zone) - Represents a price range, not a single level.
+2.  منطقة عرض عالية (High Supply Zone) - Represents a price range, not a single level.
+3.  دعم عام سابق (Previous General Support) - Requires specific logic to identify historical swing points and label them as such.
+4.  مقاومة عامة سابقة (Previous General Resistance) - Same as above.


### PR DESCRIPTION
This commit completely refactors the technical analysis report to match the new user-specified format.

- Overhauls `ReportBuilder` to generate a multi-part report that conforms to the new template.
- Modifies the `build_report` method to return a list of message objects, facilitating sequential sending.
- Updates `InteractiveTelegramBot` to send the report as a series of separate messages (header, timeframes, summary).
- Adds placeholders for analysis data points that are not yet supported by the engine (e.g., supply/demand zones).
- Creates `unsupported_analysis_fields.txt` to document these unsupported fields.
- Fixes a bug in the summary generation logic where timeframe lookups were case-sensitive.