### PR TITLE
fix: Address user feedback on report format

### DIFF
--- a/src/decision_engine/engine.py
+++ b/src/decision_engine/engine.py
@@ -98,8 +98,11 @@ class DecisionEngine:
                 conflict_note = "Bearish pattern conflicts with the bullish overall trend. Strong confirmation is recommended."
                 main_action = "Wait ⏳"
 
-        if main_action == "Wait ⏳":
-            trade_setup = None
+        # This was the root cause of the user's complaint.
+        # A trade setup should be presented if a pattern is found, even if the
+        # final recommendation is to "Wait", so the user can evaluate it.
+        # if main_action == "Wait ⏳":
+        #     trade_setup = None
 
         total_score = confidence if 'Buy' in main_action else -confidence if 'Sell' in main_action else 0
 

--- a/src/reporting/report_builder.py
+++ b/src/reporting/report_builder.py
@@ -154,25 +154,22 @@ class ReportBuilder:
 
         # --- Part 1: Executive Summary ---
         summary_section = "📌 الملخص التنفيذي والشامل\n\n"
+        # Simplified logic: Iterate through all results and create a summary line for each.
+        # This ensures every timeframe is represented, fixing the user's issue.
         timeframe_groups = self.config.get('trading', {}).get('TIMEFRAME_GROUPS', {})
         horizon_map = {tf: horizon for horizon, tfs in timeframe_groups.items() for tf in tfs}
-
-        grouped_results = {'long_term': [], 'medium_term': [], 'short_term': []}
-        for res in ranked_results:
-            # Bug fix: Ensure the lookup is case-insensitive by uppercasing the timeframe
-            horizon = horizon_map.get(res.get('timeframe', '').upper())
-            if horizon:
-                grouped_results[horizon].append(res)
-
         horizon_names = {'short_term': 'قصير المدى', 'medium_term': 'متوسط المدى', 'long_term': 'طويل المدى'}
-        for horizon, results in grouped_results.items():
-            if not results: continue
-            best_res = results[0]
-            p = best_res.get('raw_analysis', {}).get('patterns', [None])[0]
+
+        for res in ranked_results:
+            p = res.get('raw_analysis', {}).get('patterns', [None])[0]
             if p:
+                horizon_key = horizon_map.get(res.get('timeframe', '').upper(), 'N/A')
+                horizon_name = horizon_names.get(horizon_key, 'غير محدد')
+
                 targets = [t for t in [p.target1, p.target2, p.target3] if t]
                 target_str = ' → '.join([f"${t:,.0f}" for t in targets])
-                summary_section += f"{horizon_names[horizon]} ({best_res.get('timeframe').upper()}): {p.name} → اختراق {p.activation_level:,.0f}$ → أهداف: {target_str}\n"
+
+                summary_section += f"{horizon_name} ({res.get('timeframe').upper()}): {p.name} → اختراق {p.activation_level:,.0f}$ → أهداف: {target_str}\n"
 
         summary_section += "\nنقاط المراقبة الحرجة:\n"
         activations = [f"{res.get('timeframe').upper()} = ${res.get('raw_analysis', {}).get('patterns', [Pattern(name='', status='', timeframe='', activation_level=0, invalidation_level=0, target1=0)])[0].activation_level:,.0f}" for res in ranked_results if res.get('raw_analysis', {}).get('patterns')]


### PR DESCRIPTION
This commit addresses user feedback on the new analysis report format.

- Fixes the executive summary to ensure a summary line is generated for every analyzed timeframe, not just the first one in a group.
- Modifies the DecisionEngine to always generate a TradeSetup object if a pattern is detected, preventing the "No confirmed trade" message. The trade's speculative nature is conveyed through its conditions.
- Re-implements the multi-part message structure and sequential sending logic.