### PR TITLE
fix: Add missing analysis modules to orchestrator

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,8 @@ def main():
     from src.decision_engine.engine import DecisionEngine
     from src.analysis import (
         TechnicalIndicators, TrendAnalysis, PriceChannels,
-        SupportResistanceAnalysis, FibonacciAnalysis, ClassicPatterns, TrendLineAnalysis
+        SupportResistanceAnalysis, FibonacciAnalysis, ClassicPatterns, TrendLineAnalysis,
+        VolumeProfileAnalysis
     )
 
     config = get_config()
@@ -43,7 +44,8 @@ def main():
         SupportResistanceAnalysis(config=config.get('analysis')),
         FibonacciAnalysis(config=config.get('analysis')),
         ClassicPatterns(config=config.get('analysis')),
-        TrendLineAnalysis(config=config.get('analysis'))
+        TrendLineAnalysis(config=config.get('analysis')),
+        VolumeProfileAnalysis(config=config.get('analysis'))
     ]
     orchestrator = AnalysisOrchestrator(analysis_modules)
     decision_engine = DecisionEngine(config)


### PR DESCRIPTION
This commit fixes the root cause of missing support and resistance levels (specifically HVN and POC) in the analysis reports.

The `AnalysisOrchestrator` was being initialized in `main.py` with an incomplete list of analysis modules. The `VolumeProfileAnalysis` module was missing.

This change adds `VolumeProfileAnalysis` to the list, ensuring that volume-based support and resistance levels are now correctly generated and included in all analyses. This completes the data requirements for the new report format.