### PR TITLE
Fix trend line calculation for timestamp-indexed data

### DIFF
--- a/src/analysis/trend_lines.py
+++ b/src/analysis/trend_lines.py
@@ -70,10 +70,18 @@ class TrendLineAnalysis(BaseAnalysis):
         support_trend, resistance_trend = None, None
         if len(low_pivots_idx) >= 2:
             p1_idx, p2_idx = low_pivots_idx[-2], low_pivots_idx[-1]
-            support_trend = get_line_equation((p1_idx, data['low'].iloc[p1_idx]), (p2_idx, data['low'].iloc[p2_idx]))
+            p1_x_val = data.index[p1_idx]
+            p1_x = p1_x_val[0] if isinstance(p1_x_val, tuple) else p1_x_val.value
+            p2_x_val = data.index[p2_idx]
+            p2_x = p2_x_val[0] if isinstance(p2_x_val, tuple) else p2_x_val.value
+            support_trend = get_line_equation((p1_x, data['low'].iloc[p1_idx]), (p2_x, data['low'].iloc[p2_idx]))
         if len(high_pivots_idx) >= 2:
             p1_idx, p2_idx = high_pivots_idx[-2], high_pivots_idx[-1]
-            resistance_trend = get_line_equation((p1_idx, data['high'].iloc[p1_idx]), (p2_idx, data['high'].iloc[p2_idx]))
+            p1_x_val = data.index[p1_idx]
+            p1_x = p1_x_val[0] if isinstance(p1_x_val, tuple) else p1_x_val.value
+            p2_x_val = data.index[p2_idx]
+            p2_x = p2_x_val[0] if isinstance(p2_x_val, tuple) else p2_x_val.value
+            resistance_trend = get_line_equation((p1_x, data['high'].iloc[p1_idx]), (p2_x, data['high'].iloc[p2_idx]))
         return support_trend, resistance_trend
 
     def analyze(self, df: pd.DataFrame) -> Dict[str, List[Level]]:
@@ -100,15 +108,16 @@ class TrendLineAnalysis(BaseAnalysis):
         supports = []
         resistances = []
         current_price = data['close'].iloc[-1]
-        current_time_index = len(data) - 1
+        current_time_val = data.index[-1]
+        current_time_x = current_time_val[0] if isinstance(current_time_val, tuple) else current_time_val.value
 
         if support_trend:
-            support_price = support_trend['slope'] * current_time_index + support_trend['intercept']
+            support_price = support_trend['slope'] * current_time_x + support_trend['intercept']
             if support_price < current_price:
                 supports.append(Level(name="دعم الاتجاه قصير المدى", value=round(support_price, 4), level_type='support', quality='حرج'))
 
         if resistance_trend:
-            resistance_price = resistance_trend['slope'] * current_time_index + resistance_trend['intercept']
+            resistance_price = resistance_trend['slope'] * current_time_x + resistance_trend['intercept']
             if resistance_price > current_price:
                 resistances.append(Level(name="مقاومة الاتجاه قصير المدى", value=round(resistance_price, 4), level_type='resistance', quality='حرج'))
 

--- a/tests/test_trend_lines.py
+++ b/tests/test_trend_lines.py
@@ -1,0 +1,78 @@
+import pandas as pd
+import pytest
+from src.analysis.trend_lines import TrendLineAnalysis
+from src.config import get_config
+import numpy as np
+
+@pytest.fixture
+def trend_line_analysis_instance():
+    config = get_config()
+    analysis_config = config.get('analysis', {})
+    return TrendLineAnalysis(config=analysis_config)
+
+def test_trend_line_with_time_gaps(trend_line_analysis_instance, mocker):
+    """
+    Tests if the trend line calculation is correct when there are gaps in the
+    DatetimeIndex, which simulates market closures or missing data.
+    The buggy version uses integer indices for x-coordinates, leading to an
+    incorrect slope. The fixed version should use the timestamps.
+    """
+    data = {
+        'timestamp': pd.to_datetime([
+            '2023-01-01 10:00', '2023-01-01 11:00', '2023-01-01 12:00',
+            '2023-01-03 10:00', '2023-01-03 11:00', '2023-01-03 12:00',
+            '2023-01-05 10:00', '2023-01-05 11:00', '2023-01-05 12:00', '2023-01-05 13:00',
+        ]),
+        'high': [120, 120, 120, 130, 130, 130, 140, 140, 140, 150],
+        'low':  [110, 100, 110, 120, 120, 120, 130, 120, 130, 140],
+        'close': [115, 105, 115, 125, 125, 125, 135, 125, 135, 145]
+    }
+    df = pd.DataFrame(data).set_index('timestamp')
+
+    # Add more data to meet the minimum length requirement of the analyze method
+    for i in range(15):
+        new_timestamp = df.index[-1] + pd.Timedelta(hours=i+1)
+        new_data = {
+            'high': df['high'].iloc[-1] + 5,
+            'low': df['low'].iloc[-1] + 5,
+            'close': df['close'].iloc[-1] + 5
+        }
+        df.loc[new_timestamp] = new_data
+
+    # Use all data
+    trend_line_analysis_instance.long_period = len(df)
+
+    # --- Correct Calculation ---
+    pivots_df = pd.DataFrame({
+        'x': df.index.astype(np.int64),
+        'y': df['low'].values
+    })
+    p1 = (pivots_df['x'].iloc[1], pivots_df['y'].iloc[1])
+    p2 = (pivots_df['x'].iloc[7], pivots_df['y'].iloc[7])
+
+    slope = (p2[1] - p1[1]) / (p2[0] - p1[0])
+    intercept = p1[1] - slope * p1[0]
+
+    current_time_x = df.index[-1].value
+    correct_support_price = slope * current_time_x + intercept
+
+    # --- Buggy Calculation ---
+    p1_buggy = (1, df['low'].iloc[1])
+    p2_buggy = (7, df['low'].iloc[7])
+
+    slope_buggy = (p2_buggy[1] - p1_buggy[1]) / (p2_buggy[0] - p1_buggy[0])
+    intercept_buggy = p1_buggy[1] - slope_buggy * p1_buggy[0]
+
+    current_time_x_buggy = len(df) - 1
+    buggy_support_price = slope_buggy * current_time_x_buggy + intercept_buggy
+
+    # --- Run Analysis ---
+    # Mock _get_pivots to ensure it returns the pivots we expect for the test
+    mocker.patch.object(trend_line_analysis_instance, '_get_pivots', return_value=([], [1, 7]))
+    result = trend_line_analysis_instance.analyze(df)
+
+    assert len(result['supports']) == 1
+    analyzed_support_price = result['supports'][0].value
+
+    assert analyzed_support_price != pytest.approx(buggy_support_price)
+    assert analyzed_support_price == pytest.approx(correct_support_price)


### PR DESCRIPTION
The `TrendLineAnalysis` module was incorrectly using integer-based row indices as the x-coordinate for calculating trend line equations. This is incorrect for time-series data indexed by timestamps, as it ignores the actual time duration between data points, especially when there are gaps in the data (e.g., market closures).

This change corrects the trend line calculation by using the numerical value of the timestamps from the DataFrame's index as the x-coordinate. This ensures that the slope and projected support/resistance levels are time-accurate.

The fix also introduces a new test case with a gapped `DatetimeIndex` to verify the correction and prevent future regressions. The implementation has been made more robust to handle different index types that were discovered during testing.