### PR TITLE
Fix: Make timeframe parsing case-insensitive

### DIFF
--- a/src/data/okx_fetcher.py
+++ b/src/data/okx_fetcher.py
@@ -87,13 +87,14 @@ class OKXDataFetcher(BaseDataFetcher):
             int: The equivalent number of minutes. Defaults to 1440 (1 day)
             if the format is unrecognized.
         """
+        tf = timeframe.lower()
         try:
-            if 'm' in timeframe:
-                return int(timeframe.replace('m', ''))
-            elif 'H' in timeframe:
-                return int(timeframe.replace('H', '')) * 60
-            elif 'D' in timeframe:
-                return int(timeframe.replace('D', '')) * 24 * 60
+            if 'm' in tf:
+                return int(tf.replace('m', ''))
+            elif 'h' in tf:
+                return int(tf.replace('h', '')) * 60
+            elif 'd' in tf:
+                return int(tf.replace('d', '')) * 24 * 60
         except (ValueError, TypeError):
             return 1440
         return 1440

--- a/tests/test_okx_data_fetcher.py
+++ b/tests/test_okx_data_fetcher.py
@@ -1,0 +1,30 @@
+import pytest
+from src.data.okx_fetcher import OKXDataFetcher
+from src.config import get_config
+
+@pytest.fixture
+def fetcher():
+    """Returns an instance of OKXDataFetcher."""
+    config = get_config()
+    return OKXDataFetcher(config)
+
+@pytest.mark.parametrize("timeframe, expected_minutes", [
+    ('5m', 5),
+    ('15m', 15),
+    ('30m', 30),
+    ('1h', 60),
+    ('4h', 240),
+    ('1d', 1440),
+    ('1H', 60),
+    ('4H', 240),
+    ('1D', 1440),
+    ('2h', 120),
+    ('2H', 120),
+    ('3m', 3)
+])
+def test_timeframe_to_minutes(fetcher, timeframe, expected_minutes):
+    """
+    Tests the _timeframe_to_minutes method with various timeframes.
+    This test will fail for lowercase 'h' and 'd' timeframes before the fix.
+    """
+    assert fetcher._timeframe_to_minutes(timeframe) == expected_minutes


### PR DESCRIPTION
The `_timeframe_to_minutes` function in `src/data/okx_fetcher.py` was case-sensitive when parsing timeframe strings. It only recognized uppercase 'H' and 'D' for hours and days, respectively. This caused issues with lowercase timeframes like '1h' or '1d', which are used in other parts of the application.

This commit fixes the issue by converting the timeframe string to lowercase before parsing. This makes the function correctly handle both uppercase and lowercase timeframes.

A new test file, `tests/test_okx_data_fetcher.py`, has been added with a parameterized test to verify the fix. The test covers various timeframes and ensures the correct number of minutes is returned.

Note: There is a pre-existing failing test in `tests/test_analysis_results.py` due to a missing `BTC-USDT_historical.json` file. This is unrelated to the changes in this commit.