### PR TITLE
fix: Force fresh data fetch for interactive analysis

### DIFF
--- a/src/data/okx_fetcher.py
+++ b/src/data/okx_fetcher.py
@@ -295,36 +295,34 @@ class OKXDataFetcher(BaseDataFetcher):
             'data': historical_data
         }
 
-    def fetch_historical_data(self, symbol: str = 'BTC-USDT', timeframe: str = '1D', days_to_fetch: int = 730) -> Dict[str, Any]:
+    def fetch_historical_data(self, symbol: str = 'BTC-USDT', timeframe: str = '1D', days_to_fetch: int = 730, use_cache: bool = True) -> Dict[str, Any]:
         """Fetches historical data, utilizing a multi-level cache.
 
-        This method orchestrates the fetching process, following a
-        cache-then-network strategy:
-        1. Check the in-memory cache.
-        2. Check the file system cache.
-        3. Fetch from the network API if not found in any cache.
-        The result is then stored in both caches for future requests.
+        This method orchestrates the fetching process. It can be forced to
+        ignore the cache and fetch fresh data from the network.
 
         Args:
             symbol (str, optional): The trading symbol. Defaults to 'BTC-USDT'.
             timeframe (str, optional): The timeframe string. Defaults to '1D'.
             days_to_fetch (int, optional): The number of days to fetch.
                 Defaults to 730.
+            use_cache (bool, optional): If False, forces a fetch from the
+                network, ignoring any cached data. Defaults to True.
 
         Returns:
             Dict[str, Any]: The processed historical data, or an empty dict
             if fetching fails.
         """
-        cache_key = (symbol, timeframe, days_to_fetch)
+        if use_cache:
+            cache_key = (symbol, timeframe, days_to_fetch)
+            cached_data = self._read_from_cache(cache_key)
+            if cached_data:
+                return cached_data
 
-        cached_data = self._read_from_cache(cache_key)
-        if cached_data:
-            return cached_data
-
-        file_data = self._read_from_file(symbol, timeframe)
-        if file_data:
-            self.historical_cache[cache_key] = file_data
-            return file_data
+            file_data = self._read_from_file(symbol, timeframe)
+            if file_data:
+                self.historical_cache[cache_key] = file_data
+                return file_data
 
         raw_candles = self._fetch_from_network(symbol, timeframe, days_to_fetch)
         if not raw_candles:

--- a/src/notifiers/telegram_notifier.py
+++ b/src/notifiers/telegram_notifier.py
@@ -98,7 +98,7 @@ class InteractiveTelegramBot(BaseNotifier):
                 okx_symbol = symbol.replace('/', '-')
                 api_timeframe = tf.replace('d', 'D').replace('h', 'H')
                 historical_data_wrapper = await anyio.to_thread.run_sync(
-                    self.fetcher.fetch_historical_data, okx_symbol, api_timeframe
+                    self.fetcher.fetch_historical_data, okx_symbol, api_timeframe, use_cache=False
                 )
                 if not historical_data_wrapper or not historical_data_wrapper.get('data'):
                     raise ConnectionError(f"Failed to fetch data for {symbol} on {tf}")


### PR DESCRIPTION
Resolves a critical bug where reports would show 'N/A' for most fields.

The root cause was that the data fetcher was using stale/incomplete data from a local file cache for certain symbols. The analysis modules were failing to find levels in this data, leading to empty results.

This fix introduces a `use_cache` parameter to the `fetch_historical_data` method in the OKXDataFetcher and sets it to `False` for all user-initiated analysis requests from the Telegram bot. This ensures that a fresh, live dataset is always used, allowing the analysis to function correctly.