### PR TITLE
Fix: Make symbol validation case-insensitive

### DIFF
--- a/src/analysis/trend_lines.py
+++ b/src/analysis/trend_lines.py
@@ -1,8 +1,11 @@
 import pandas as pd
+import logging
 from scipy.signal import find_peaks
 from typing import Dict, Any, Optional, List
 from .base_analysis import BaseAnalysis
 from .data_models import Level
+
+logger = logging.getLogger(__name__)
 
 def get_line_equation(p1: tuple, p2: tuple) -> Optional[Dict[str, float]]:
     """Calculates the slope and intercept of a line defined by two points.

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -28,7 +28,7 @@ def validate_symbol_timeframe(symbol: str, timeframe: str):
     Raises:
         ValueError: If the symbol or timeframe is not supported.
     """
-    okx_symbol = symbol.replace('/', '-')
+    okx_symbol = symbol.replace('/', '-').upper()
     if okx_symbol not in SUPPORTED_COMBINATIONS:
         raise ValueError(f"Symbol {symbol} is not supported.")
 


### PR DESCRIPTION
The `validate_symbol_timeframe` function in `src/utils/validators.py` was case-sensitive when checking for supported symbols. It did not convert the input symbol to uppercase before looking it up in the `SUPPORTED_COMBINATIONS` dictionary, which uses uppercase keys. This caused valid symbols to be rejected if they were provided in lowercase (e.g., 'btc/usdt').

This change corrects the behavior by converting the symbol to uppercase before the lookup, ensuring that the validation is case-insensitive as intended.

Additionally, this change includes a fix for a pre-existing bug in `src/analysis/trend_lines.py` where a `logger` was used without being defined. This was causing several tests to fail, and the fix was necessary to ensure the entire test suite passes, confirming that the primary change did not introduce any regressions.