### PR TITLE
fix(analysis): Correct imports in analysis package

### DIFF
--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -6,8 +6,7 @@ top-level `analysis` package, simplifying imports in other parts of the applicat
 
 from .base_analysis import BaseAnalysis
 from .trends import TrendAnalysis
-from .trend_lines import TrendLineAnalysis
-from .channels import PriceChannels
+from .quantile_channel_analysis import QuantileChannelAnalysis
 from .new_support_resistance import NewSupportResistanceAnalysis
 from .fibonacci import FibonacciAnalysis
 from .classic_patterns import ClassicPatterns


### PR DESCRIPTION
This commit resolves a `ModuleNotFoundError` that caused the application to crash on startup.

The error was caused by outdated import statements in `src/analysis/__init__.py` that were pointing to modules (`trend_lines.py`, `channels.py`) which had been deleted in a previous refactoring.

The fix updates the `__init__.py` file to:
- Remove the incorrect imports for `TrendLineAnalysis` and `PriceChannels`.
- Add the correct import for the new `QuantileChannelAnalysis` module.

This brings the package's public interface in sync with its file structure and allows the application to run correctly.