### PR TITLE
fix(analysis): Resolve cascading import errors after refactor

### DIFF
--- a/src/analysis/__init__.py
+++ b/src/analysis/__init__.py
@@ -5,9 +5,10 @@ top-level `analysis` package, simplifying imports in other parts of the applicat
 """
 
 from .base_analysis import BaseAnalysis
-from .trends import TrendAnalysis
-from .quantile_channel_analysis import QuantileChannelAnalysis
-from .new_support_resistance import NewSupportResistanceAnalysis
-from .fibonacci import FibonacciAnalysis
 from .classic_patterns import ClassicPatterns
+from .fibonacci import FibonacciAnalysis
+from .new_support_resistance import NewSupportResistanceAnalysis
 from .orchestrator import AnalysisOrchestrator
+from .pivot_detector import PivotDetector
+from .quantile_channel_analysis import QuantileChannelAnalysis
+from .trends import TrendAnalysis


### PR DESCRIPTION
This commit resolves all `ImportError` and `ModuleNotFoundError` exceptions that occurred after the major analysis engine overhaul.

The errors were caused by dangling import statements in `src/analysis/__init__.py` and `main.py` that were not updated after modules were deleted or replaced.

The fix includes:
- Updating `src/analysis/__init__.py` to correctly export the new and existing analysis modules, including `QuantileChannelAnalysis` and `PivotDetector`.
- Updating `main.py` to remove references to deleted modules and correctly import the new ones for use in CLI mode.
- Updating `src/notifiers/telegram_notifier.py` to correctly import `PivotDetector` from the analysis package.

This brings all parts of the application in sync with the new, refactored module structure, resolving the startup crashes.