### PR TITLE
Fix(indicators): Correct indexing in divergence detection

### DIFF
--- a/src/utils/indicators.py
+++ b/src/utils/indicators.py
@@ -20,16 +20,16 @@ def find_swing_points(data: pd.DataFrame, lookback: int, prominence_multiplier: 
 
     result = {'highs': [], 'lows': []}
     for i in high_peaks_indices:
-        result['highs'].append({'price': recent_data.iloc[i]['high'], 'index': i})
+        result['highs'].append({'price': recent_data.iloc[i]['high'], 'index': recent_data.index[i]})
     for i in low_peaks_indices:
-        result['lows'].append({'price': recent_data.iloc[i]['low'], 'index': i})
+        result['lows'].append({'price': recent_data.iloc[i]['low'], 'index': recent_data.index[i]})
 
     abs_high_idx = recent_data['high'].idxmax()
     abs_low_idx = recent_data['low'].idxmin()
-    if not any(p['index'] == recent_data.index.get_loc(abs_high_idx) for p in result['highs']):
-         result['highs'].append({'price': recent_data.loc[abs_high_idx]['high'], 'index': recent_data.index.get_loc(abs_high_idx)})
-    if not any(p['index'] == recent_data.index.get_loc(abs_low_idx) for p in result['lows']):
-         result['lows'].append({'price': recent_data.loc[abs_low_idx]['low'], 'index': recent_data.index.get_loc(abs_low_idx)})
+    if not any(p['index'] == abs_high_idx for p in result['highs']):
+         result['highs'].append({'price': recent_data.loc[abs_high_idx]['high'], 'index': abs_high_idx})
+    if not any(p['index'] == abs_low_idx for p in result['lows']):
+         result['lows'].append({'price': recent_data.loc[abs_low_idx]['low'], 'index': abs_low_idx})
 
     result['highs'] = sorted(result['highs'], key=lambda x: x['index'])
     result['lows'] = sorted(result['lows'], key=lambda x: x['index'])
@@ -45,8 +45,8 @@ def detect_divergence(price_swings: List[Dict[str, Any]], indicator_series: pd.S
     prev_swing = price_swings[-2]
     last_price = last_swing['price']
     prev_price = prev_swing['price']
-    last_indicator = indicator_series.iloc[last_swing['index']]
-    prev_indicator = indicator_series.iloc[prev_swing['index']]
+    last_indicator = indicator_series.loc[last_swing['index']]
+    prev_indicator = indicator_series.loc[prev_swing['index']]
 
     if type == 'bullish' and last_price < prev_price and last_indicator > prev_indicator:
         return True

--- a/tests/test_bug_fix.py
+++ b/tests/test_bug_fix.py
@@ -1,0 +1,47 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from src.utils.indicators import find_swing_points, detect_divergence
+
+def test_divergence_is_detected_after_fix():
+    """
+    This test verifies that the divergence detection bug is fixed.
+    It creates a scenario with a clear bearish divergence and asserts that
+    the fixed function correctly detects it.
+    """
+    # 1. Create a robust dataset with bearish divergence
+    data_len = 200
+    price_data = np.linspace(100, 150, data_len)
+    rsi_data = np.linspace(40, 80, data_len)
+
+    # Create the first price peak and a corresponding high RSI peak
+    price_data[150] = 160
+    rsi_data[150] = 85 # RSI Peak 1
+
+    # Create a higher peak in price, but a lower peak in RSI (the divergence)
+    price_data[180] = 165 # Higher High in price
+    rsi_data[180] = 80  # Lower High in RSI
+
+    df = pd.DataFrame({
+        'high': price_data,
+        'low': price_data - 5,
+        'close': price_data - 2,
+        'rsi': rsi_data,
+        'volume': np.random.randint(100, 1000, data_len)
+    })
+    # Use a non-zero-based index to simulate real-world data
+    df.index = range(100, 100 + data_len)
+
+    # 2. Find swing points
+    swings = find_swing_points(df, lookback=100, prominence_multiplier=0.1)
+
+    # Sanity check that our peaks are found
+    assert len(swings['highs']) >= 2
+
+    # 3. Detect divergence
+    is_divergence_present = detect_divergence(swings['highs'], df['rsi'], 'bearish')
+
+    # 4. Assert the fix is working
+    # The fixed function should now correctly identify the divergence.
+    assert is_divergence_present is True, "The bug is not fixed. The function still fails to detect the divergence."


### PR DESCRIPTION
The `detect_divergence` function was failing to correctly identify divergences when the pandas DataFrame had a non-zero-based or non-sequential index (e.g., timestamps).

This was caused by two issues:
1.  `find_swing_points` stored the positional integer index of a swing point instead of its actual DataFrame label.
2.  `detect_divergence` then used this positional index with `.iloc` to look up the corresponding indicator value, leading to a mismatch between the price swing and the indicator value being compared.

This commit corrects the issue by:
- Modifying `find_swing_points` to always store the true DataFrame index label for each swing point.
- Updating `detect_divergence` to use `.loc` for lookups, ensuring the correct indicator value is retrieved using the stored index label.

A new test case has been added to verify that divergence is now correctly detected with a non-zero-based index.