### PR TITLE
Fix(formatter): Prevent KeyError crash on missing analysis data

### DIFF
--- a/src/utils/formatter.py
+++ b/src/utils/formatter.py
@@ -15,9 +15,15 @@ def format_analysis_from_template(analysis_data: Dict[str, Any], symbol: str, ti
 
     now = datetime.now()
 
-    # --- Helper for safe formatting ---
+    # --- Helpers for safe formatting ---
     def format_price(price):
         return f"${price:.2f}" if price and isinstance(price, (int, float)) and price > 0 else "غير متاح"
+
+    def format_date(timestamp):
+        if not timestamp or not isinstance(timestamp, (int, float)):
+            return "غير متاح"
+        # OKX timestamp is in milliseconds
+        return datetime.fromtimestamp(timestamp / 1000).strftime('%Y-%m-%d')
 
     # --- Main Signal ---
     signal = analysis_data.get('signal', 'HOLD')
@@ -28,12 +34,15 @@ def format_analysis_from_template(analysis_data: Dict[str, Any], symbol: str, ti
     trend = analysis_data.get('trend', 'N/A')
     trend_emoji = '🔼' if trend == 'up' else '🔽'
 
-    # --- Fibonacci Levels ---
+    # --- Fibonacci Levels & Swings ---
     retracements = analysis_data.get('retracements', {})
     extensions = analysis_data.get('extensions', {})
+    swing_high = analysis_data.get('swing_high', {})
+    swing_low = analysis_data.get('swing_low', {})
 
-    # --- Risk Levels ---
-    risk_levels = analysis_data.get('risk_levels', {})
+    # --- Other data points ---
+    scenarios = analysis_data.get('scenarios', {})
+    risk_levels = analysis_data.get('risk_levels', {}) # This seems unused in the template
 
     # --- Build Replacements Dictionary ---
     replacements = {
@@ -48,8 +57,11 @@ def format_analysis_from_template(analysis_data: Dict[str, Any], symbol: str, ti
         "trend_emoji": trend_emoji,
         "trend": "صاعد" if trend == 'up' else "هابط",
         "current_price": format_price(analysis_data.get('current_price')),
-        "swing_high_price": format_price(analysis_data.get('swing_high', {}).get('price')),
-        "swing_low_price": format_price(analysis_data.get('swing_low', {}).get('price')),
+
+        "swing_high": format_price(swing_high.get('price')),
+        "swing_high_date": format_date(swing_high.get('index')),
+        "swing_low": format_price(swing_low.get('price')),
+        "swing_low_date": format_date(swing_low.get('index')),
 
         "fib_236": format_price(retracements.get('fib_236')),
         "fib_382": format_price(retracements.get('fib_382')),
@@ -64,10 +76,45 @@ def format_analysis_from_template(analysis_data: Dict[str, Any], symbol: str, ti
         "ext_2618": format_price(extensions.get('ext_2618')),
 
         "pattern": analysis_data.get('pattern', 'لا يوجد'),
-        "entry_point": format_price(risk_levels.get('entry')),
-        "stop_loss": format_price(risk_levels.get('stop_loss')),
-        "target_1": format_price(risk_levels.get('targets', [None])[0]),
-        "target_2": format_price(risk_levels.get('targets', [None, None])[1]),
+
+        # --- Defaulting complex keys that need to be implemented in the analyzer ---
+        "confirmation_break_618": "⚪️",
+        "confirmation_daily_close": "⚪️",
+        "fib_618_val": format_price(retracements.get('fib_618')),
+        "confirmation_volume": "⚪️",
+        "confirmation_rsi": "⚪️",
+        "confirmation_reversal_candle": "⚪️",
+        "pattern_confirm_hammer": "⚪️",
+        "pattern_confirm_engulfing": "⚪️",
+        "pattern_confirm_break_doji": "⚪️",
+        "pattern_confirm_close_above": "⚪️",
+        "pattern_confirm_volume": "⚪️",
+        "scenario1_title": scenarios.get('scenario1', {}).get('title', 'N/A'),
+        "scenario1_prob": scenarios.get('scenario1', {}).get('prob', 'N/A'),
+        "scenario1_target": format_price(scenarios.get('scenario1', {}).get('target')),
+        "scenario1_entry": format_price(scenarios.get('scenario1', {}).get('entry')),
+        "scenario1_stop_loss": format_price(scenarios.get('scenario1', {}).get('stop_loss')),
+        "scenario2_title": scenarios.get('scenario2', {}).get('title', 'N/A'),
+        "scenario2_prob": scenarios.get('scenario2', {}).get('prob', 'N/A'),
+        "scenario2_target": format_price(scenarios.get('scenario2', {}).get('target')),
+        "scenario2_entry": format_price(scenarios.get('scenario2', {}).get('entry')),
+        "scenario2_stop_loss": format_price(scenarios.get('scenario2', {}).get('stop_loss')),
+        "scenario3_title": "غير محدد", "scenario3_prob": "N/A", "scenario3_target": "N/A",
+        "scenario3_entry": "N/A", "scenario3_stop_loss": "N/A",
+        "trade_title": "لا توجد صفقة مؤكدة حاليًا",
+        "trade_entry": "N/A",
+        "trade_confirm_close": "⚪️",
+        "trade_confirm_volume": "⚪️",
+        "trade_confirm_macd": "⚪️",
+        "trade_confirm_trendline": "⚪️",
+        "trade_target1": "N/A",
+        "trade_target2": "N/A",
+        "trade_target3": "N/A",
+        "trade_stop_loss": "N/A",
     }
 
-    return template.format(**replacements)
+    # Using format_map with a custom dict to avoid crashing on any other missing keys
+    class SafeFormatter(dict):
+        def __missing__(self, key):
+            return f'{{{key}}}'
+    return template.format_map(SafeFormatter(replacements))


### PR DESCRIPTION
The bot was crashing with a `KeyError` when trying to format the analysis report. This was because the report template expected more keys than the `FiboAnalyzer` was providing.

This commit prevents the crash by making the formatter more robust:
- It correctly formats the `swing_high` and `swing_low` data, including their dates, resolving the specific `KeyError: 'swing_high'`.
- It adds default placeholder values for all other keys required by the template.
- It implements a `SafeFormatter` class to ensure that any future missing keys will not cause a crash, but will instead be displayed in the report, making debugging easier.

This is an incremental fix to restore the bot's basic functionality. The underlying analysis logic in `FiboAnalyzer` still needs to be expanded to provide all the data expected by the template.