### PR TITLE
feat: Implement wide-scope analysis with paginated data fetching

### DIFF
--- a/src/utils/indicators.py
+++ b/src/utils/indicators.py
@@ -3,60 +3,9 @@ import numpy as np
 from scipy.signal import find_peaks
 from typing import Dict, List, Any
 
-def find_classic_swings(data: pd.DataFrame) -> Dict[str, List[Dict[str, Any]]]:
-    """
-    Finds swing points using the classic technical analysis method:
-    - A swing high is a candle with 2 lower highs on each side.
-    - A swing low is a candle with 2 higher lows on each side.
-    """
-    if len(data) < 5:
-        return {'highs': [], 'lows': []}
-
-    highs = []
-    lows = []
-
-    for i in range(2, len(data) - 2):
-        # Check for Swing High
-        is_swing_high = (
-            data['high'].iloc[i] > data['high'].iloc[i-1] and
-            data['high'].iloc[i] > data['high'].iloc[i-2] and
-            data['high'].iloc[i] > data['high'].iloc[i+1] and
-            data['high'].iloc[i] > data['high'].iloc[i+2]
-        )
-        if is_swing_high:
-            highs.append({'price': data['high'].iloc[i], 'index': data.index[i]})
-
-        # Check for Swing Low
-        is_swing_low = (
-            data['low'].iloc[i] < data['low'].iloc[i-1] and
-            data['low'].iloc[i] < data['low'].iloc[i-2] and
-            data['low'].iloc[i] < data['low'].iloc[i+1] and
-            data['low'].iloc[i] < data['low'].iloc[i+2]
-        )
-        if is_swing_low:
-            lows.append({'price': data['low'].iloc[i], 'index': data.index[i]})
-
-    return {'highs': highs, 'lows': lows}
 
 
 
-def detect_divergence(price_swings: List[Dict[str, Any]], indicator_series: pd.Series, type: str = 'bullish') -> bool:
-    """Detects bullish or bearish divergence between price and an indicator."""
-    if len(price_swings) < 2:
-        return False
-
-    last_swing = price_swings[-1]
-    prev_swing = price_swings[-2]
-    last_price = last_swing['price']
-    prev_price = prev_swing['price']
-    last_indicator = indicator_series.iloc[last_swing['index']]
-    prev_indicator = indicator_series.iloc[prev_swing['index']]
-
-    if type == 'bullish' and last_price < prev_price and last_indicator > prev_indicator:
-        return True
-    elif type == 'bearish' and last_price > prev_price and last_indicator < prev_indicator:
-        return True
-    return False
 
 def calculate_sma(data: pd.DataFrame, window: int) -> pd.Series:
     if 'close' not in data.columns: raise ValueError("Input DataFrame must have a 'close' column.")

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -152,7 +152,23 @@ async def run_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         fetcher = DataFetcher(config)
         analyzer = FiboAnalyzer(config, fetcher)
 
-        data_dict = fetcher.fetch_historical_data(symbol, timeframe, limit=300)
+        # Define the number of candles to fetch per timeframe as requested
+        candle_limits = {
+            '3m': 10000,
+            '5m': 8000,
+            '15m': 5000,
+            '30m': 3000,
+            '1H': 2000,
+            '4H': 1000,
+            '1D': 500
+        }
+
+        # Get the appropriate limit for the selected timeframe, with a fallback
+        limit = candle_limits.get(timeframe, 300)
+
+        await query.edit_message_text(text=f"⏳ شكراً لك! جاري تحميل {limit} شمعة لعملة {symbol} على إطار {timeframe}...")
+
+        data_dict = fetcher.fetch_historical_data(symbol, timeframe, limit=limit)
         if not data_dict or 'data' not in data_dict or not data_dict['data']:
             await query.message.reply_text("عذراً، لم أتمكن من جلب البيانات لهذه العملة. يرجى المحاولة مرة أخرى.")
             await start(update, context)


### PR DESCRIPTION
- Refactors the DataFetcher to support paginated API calls, allowing the bot to fetch thousands of historical candles, far exceeding the single-request API limit.
- Implements a new configuration in the Telegram bot to specify the number of candles to fetch for each timeframe (e.g., 10k for 3m, 500 for 1D).
- Radically simplifies the analysis logic in FiboAnalyzer to use the entire fetched dataset. It now finds the absolute highest high and lowest low to define the main swing for Fibonacci analysis, providing the "widest possible scope" as requested.
- Cleans up the codebase by removing all previous, now-obsolete swing point detection functions (`find_classic_swings`, `calculate_zigzag`, etc.).