### PR TITLE
feat: Implement wide-scope analysis and paginated data fetching

### DIFF
--- a/src/strategies/fibo_analyzer.py
+++ b/src/strategies/fibo_analyzer.py
@@ -7,7 +7,7 @@ from ..utils.indicators import (
     calculate_sma, calculate_fib_levels,
     calculate_fib_extensions, calculate_rsi, calculate_macd,
     calculate_stochastic, calculate_bollinger_bands, calculate_adx,
-    calculate_atr, find_classic_swings
+    calculate_atr
 )
 from ..utils.patterns import get_candlestick_pattern
 
@@ -65,7 +65,6 @@ class FiboAnalyzer(BaseStrategy):
         pattern = get_candlestick_pattern(data.iloc[-3:])
 
         if trend == 'up':
-            if detect_divergence(swings['lows'], data['rsi'], 'bullish'): score += 3; reasons.append("🔥 انحراف إيجابي (RSI)")
             if zones: score += 2; reasons.append(f"منطقة توافق قرب ${zones[0]['level']:.2f}")
             if latest['rsi'] > 50:
                 score += 1; reasons.append("RSI > 50"); confirmations["confirmation_rsi"] = True
@@ -79,7 +78,6 @@ class FiboAnalyzer(BaseStrategy):
                 confirmations["confirmation_break_618"] = True
 
         else: # downtrend
-            if detect_divergence(swings['highs'], data['rsi'], 'bearish'): score += 3; reasons.append("🔥 انحراف سلبي (RSI)")
             if zones: score += 2; reasons.append(f"منطقة توافق قرب ${zones[0]['level']:.2f}")
             if latest['rsi'] < 50:
                 score += 1; reasons.append("RSI < 50"); confirmations["confirmation_rsi"] = True


### PR DESCRIPTION
- Refactors the DataFetcher to support paginated API calls, allowing the bot to fetch thousands of historical candles, far exceeding the single-request API limit.
- Implements a new configuration in the Telegram bot to specify the number of candles to fetch for each timeframe (e.g., 10k for 3m, 500 for 1D).
- Radically simplifies the analysis logic in FiboAnalyzer to use the entire fetched dataset. It now finds the absolute highest high and lowest low to define the main swing for Fibonacci analysis, providing the "widest possible scope" as requested.
- Cleans up the codebase by removing all previous, now-obsolete swing point detection functions.
- Fixes an ImportError and a bug in the order of operations discovered during testing.