### PR TITLE
feat: Implement widest-range analysis and paginated data fetching

### DIFF
--- a/src/strategies/fibo_analyzer.py
+++ b/src/strategies/fibo_analyzer.py
@@ -118,8 +118,7 @@ class FiboAnalyzer(BaseStrategy):
 
     def get_analysis(self, data: pd.DataFrame, symbol: str, timeframe: str) -> Dict[str, Any]:
         result = self._initialize_result()
-        if len(data) < 200: # Ensure we have enough data for robust analysis
-            result['reason'] = 'Not enough data'; return result
+        # A data length check will be performed after indicator calculation
 
         # --- 1. Calculate all indicators and clean data FIRST ---
         data['adx'] = calculate_adx(data, window=self.adx_window)

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -152,21 +152,10 @@ async def run_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
         fetcher = DataFetcher(config)
         analyzer = FiboAnalyzer(config, fetcher)
 
-        # Define the number of candles to fetch per timeframe as requested
-        candle_limits = {
-            '3m': 10000,
-            '5m': 8000,
-            '15m': 5000,
-            '30m': 3000,
-            '1H': 2000,
-            '4H': 1000,
-            '1D': 500
-        }
+        # Set a very large limit to fetch all available historical data
+        limit = 50000
 
-        # Get the appropriate limit for the selected timeframe, with a fallback
-        limit = candle_limits.get(timeframe, 300)
-
-        await query.edit_message_text(text=f"⏳ شكراً لك! جاري تحميل {limit} شمعة لعملة {symbol} على إطار {timeframe}...")
+        await query.edit_message_text(text=f"⏳ شكراً لك! جاري تحميل أقصى بيانات متاحة لعملة {symbol} على إطار {timeframe}...")
 
         data_dict = fetcher.fetch_historical_data(symbol, timeframe, limit=limit)
         if not data_dict or 'data' not in data_dict or not data_dict['data']:


### PR DESCRIPTION
This major feature update addresses the user's core request for a more comprehensive, wide-scope analysis.

- Refactors the DataFetcher to support paginated API calls, allowing the bot to fetch the maximum available historical candles (up to a ceiling of 50k), far exceeding the single-request API limit.
- Modifies the analysis logic in FiboAnalyzer to use the entire fetched dataset. It now finds the absolute highest high and lowest low to define the main swing for Fibonacci analysis, providing the "widest possible scope".
- Lowers the minimum data requirement to 50 candles to gracefully handle assets with limited history and prevent "Not enough data" errors.
- Cleans up the codebase by removing all previous, now-obsolete swing point detection functions (`find_classic_swings`, `detect_divergence`, etc.).
- Fixes an ImportError and a bug in the order of operations discovered during testing.