### PR TITLE
إصلاح: زيادة حد البيانات التي يتم جلبها للتحليل

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -167,7 +167,7 @@ async def run_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE) -> in
     try:
         await query.edit_message_text(text=get_text("fetching_data").format(symbol=symbol, timeframe=timeframe))
 
-        df = await _fetch_and_prepare_data(fetcher, symbol, timeframe, limit=1000)
+        df = await _fetch_and_prepare_data(fetcher, symbol, timeframe, limit=1500)
 
         await query.edit_message_text(text=get_text("analysis_running").format(symbol=symbol, timeframe=timeframe))
         analysis_info = analyzer.get_analysis(df, symbol, timeframe)


### PR DESCRIPTION
تم زيادة الحد الأقصى لعدد الشموع التي يتم جلبها من 1000 إلى 1500 في دالة `run_analysis` ضمن `telegram_bot.py`.

السبب:
كانت عملية التحليل تفشل مع ظهور خطأ "Not enough data after indicator calculations". يحدث هذا الخطأ لأن حساب المؤشرات الفنية (خاصة SMA 200) يتطلب عدداً كبيراً من نقاط البيانات، وبعد إزالة الصفوف التي تحتوي على قيم فارغة (`NaN`)، قد لا يتبقى عدد كافٍ من السجلات (أقل من 50) لمتابعة التحليل، خاصة إذا كانت المنصة لا توفر الـ 1000 شمعة كاملة المطلوبة.

الحل:
زيادة الحد إلى 1500 تضمن وجود هامش كافٍ من البيانات بعد حساب المؤشرات، مما يمنع حدوث الخطأ ويجعل عملية التحليل أكثر استقرارًا وموثوقية عبر مختلف الأطر الزمنية والعملات.