### PR TITLE
إصلاح: إزالة التنظيف المسبق للبيانات الذي كان السبب الجذري لخطأ عدم ك…

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -149,7 +149,7 @@ async def _fetch_and_prepare_data(fetcher: DataFetcher, symbol: str, timeframe: 
     numeric_cols = ['open', 'high', 'low', 'close', 'volume', 'timestamp']
     for col in numeric_cols:
         df[col] = pd.to_numeric(df[col], errors='coerce')
-    df.dropna(inplace=True)
+    # df.dropna(inplace=True) # This premature cleaning is the root cause of the issue.
     return df
 
 async def run_analysis(update: Update, context: ContextTypes.DEFAULT_TYPE) -> int:


### PR DESCRIPTION
…فاية البيانات

تم تعطيل السطر `df.dropna(inplace=True)` ضمن دالة `_fetch_and_prepare_data` في `telegram_bot.py`.

السبب الجذري الحقيقي:
لم تكن المشكلة في كمية البيانات التي يتم جلبها، بل في معالجتها الأولية. كان هذا السطر يقوم بحذف أي صف يحتوي على بيانات غير مكتملة (حتى لو كانت قيمة واحدة فارغة) قبل إرسال مجموعة البيانات إلى وحدة التحليل. هذا الإجراء كان يتسبب في تقليص مجموعة البيانات بشكل كبير وغير متوقع، مما يؤدي إلى عدم وجود بيانات كافية لحساب المؤشرات لاحقًا.

الحل:
بتعطيل هذا السطر، يتم الآن تمرير مجموعة البيانات الكاملة التي تم جلبها إلى وحدة التحليل (`FiboAnalyzer`). هذه الوحدة مصممة بالفعل للتعامل مع البيانات وتنظيفها بشكل صحيح بعد حساب المؤشرات، مما يضمن عدم فقدان أي بيانات قيمة بشكل غير ضروري.

هذا الإصلاح يعالج المشكلة من جذورها ويضمن استقرار وموثوقية عملية التحليل.