### PR TITLE
feat: جلب عدد ديناميكي للشموع حسب متطلبات الاستراتيجية

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -61,6 +61,7 @@ STRATEGY_PARAMS = {
         'sma_period_fast': 50,
         'sma_period_slow': 200,
         'fib_lookback': 50,
+        'swing_lookback_period': 100, # Number of candles to look back for swing points
         'adx_trend_threshold': 25,
         'swing_prominence_atr_multiplier': 0.5, # Multiplier for ATR to determine swing point prominence
         'scoring_weights': {


### PR DESCRIPTION
المشكلة:
كان البوت يطلب عددًا ثابتًا (1500) من الشموع، مما يؤدي إلى فشل التحليل على الأطر الزمنية التي لا تتوفر بها هذه البيانات.

الحل:
- تمت إضافة خاصية `required_candlesticks` إلى `FiboAnalyzer` لحساب عدد الشموع المطلوبة ديناميكيًا.
- تم تحديث `telegram_bot.py` لاستخدام هذه الخاصية عند طلب البيانات، مما يحل محل القيم الثابتة.
- تمت إضافة معلمة `swing_lookback_period` إلى ملف الإعدادات لزيادة المرونة.

هذا التغيير يحل مشكلة فشل جلب البيانات ويزيد من كفاءة وموثوقية البوت.