### PR TITLE
feat: إضافة إعدادات مخصصة لجلب الشموع وتنفيذ طلب المستخدم

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -32,7 +32,15 @@ TRADING_CONFIG = {
     'TRADE_AMOUNT': '0.001',
 
     # Interval for periodic analysis in minutes
-    'ANALYSIS_INTERVAL_MINUTES': 15
+    'ANALYSIS_INTERVAL_MINUTES': 15,
+
+    # --- Candle Fetching Limits ---
+    # Defines how many candles to fetch for analysis.
+    # 'default' is used for any timeframe not explicitly listed.
+    'CANDLE_FETCH_LIMITS': {
+        'default': 1000,
+        '1D': 360
+    }
 }
 
 # --- Exchange Connection ---

--- a/src/strategies/fibo_analyzer.py
+++ b/src/strategies/fibo_analyzer.py
@@ -51,22 +51,6 @@ class FiboAnalyzer(BaseStrategy):
         self.adx_threshold = p.get('adx_trend_threshold', 25)
         self.swing_atr_multiplier = p.get('swing_prominence_atr_multiplier', 0.5)
 
-    @property
-    def required_candlesticks(self) -> int:
-        """
-        Calculate the minimum number of candlesticks required for the analysis.
-        This is based on the longest indicator period plus the swing lookback period,
-        with a small buffer for safety.
-        """
-        longest_indicator = max(
-            self.sma_slow_period, self.sma_fast_period, self.rsi_period,
-            self.adx_window, self.atr_window, self.stoch_window
-        )
-        # We need enough data for the longest indicator AND the swing lookback.
-        # The total required is the indicator warm-up period plus the period to find swings in.
-        # We add a larger safety buffer to account for potential missing candles from the exchange API.
-        return longest_indicator + self.swing_lookback_period + 50 # 50 as a safety buffer
-
     def _initialize_result(self) -> Dict[str, Any]:
         """Initializes a default result dictionary."""
         return {


### PR DESCRIPTION
هذا التحديث يطبق الحل النهائي والمباشر لمشكلة جلب البيانات بناءً على طلب المستخدم المحدد.

- تمت إضافة قسم `CANDLE_FETCH_LIMITS` جديد في `config.py` للتحكم الدقيق في عدد الشموع التي يتم جلبها.
- تم ضبط الإعدادات الافتراضية لجلب 1000 شمعة، مع تخصيص 360 شمعة لفريم `1D` كما هو مطلوب.
- تم تحديث `telegram_bot.py` في جميع أجزائه (التحليل الفوري والدوري) لاستخدام هذه الإعدادات الجديدة.
- تم تنظيف الكود بإزالة الخاصية `required_candlesticks` التي لم تعد مستخدمة.
- يتضمن هذا التحديث أيضًا الميزات التي تمت الموافقة عليها مسبقًا مثل استراتيجية التكيف مع الفريمات الزمنية وأوامر عرض الرصيد والصفقات.