### PR TITLE
تحديث تنسيق عرض نسب فيبوناتشي

### DIFF
--- a/src/strategies/fibo_analyzer.py
+++ b/src/strategies/fibo_analyzer.py
@@ -262,7 +262,8 @@ class FiboAnalyzer(BaseStrategy):
         fib_levels_to_add = ['fib_382', 'fib_500', 'fib_618']
         for key in fib_levels_to_add:
             if key in retracements:
-                levels.append({'level': retracements[key], 'type': f"Fibo {key.split('_')[1]}%"})
+                level_ratio = int(key.split('_')[1]) / 1000
+                levels.append({'level': retracements[key], 'type': f"Fibo {level_ratio}"})
 
         # Sort levels by price
         levels.sort(key=lambda x: x['level'], reverse=True)


### PR DESCRIPTION
بناءً على طلب المستخدم، تم تعديل طريقة عرض نسب فيبوناتشي في قسم 'مستويات الدعم والمقاومة' لتظهر بالشكل العشري (مثل 0.618, 0.5) بدلاً من النسبة المئوية. هذا التغيير يجعل التقرير أكثر توافقًا مع المعايير الفنية الاحترافية.