### PR TITLE
تحسين منطق تحديد القمم والقيعان

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -81,7 +81,7 @@ STRATEGY_PARAMS = {
         'sma_period_fast': 50,
         'sma_period_slow': 200,
         'fib_lookback': 50,
-        'swing_lookback_period': 100,
+        'swing_lookback_period': 50,
         'adx_trend_threshold': 25,
         'signal_threshold': 5, # Minimum score required to generate a BUY/SELL signal
         'require_adx_confirmation': True, # If True, a signal is only generated if ADX is above the threshold


### PR DESCRIPTION
بناءً على ملاحظات المستخدم، تم تعديل منطق تحديد القمم والقيعان ليكون أكثر تركيزًا على حركة السعر الحديثة.

تم تقليل قيمة `swing_lookback_period` في `src/config.py` من 100 إلى 50. هذا التغيير يجبر المحلل على البحث عن نقاط الانعكاس في آخر 50 شمعة فقط، مما يمنعه من التأثر بالقمم والقيعان القديمة وغير ذات الصلة ويجعله أكثر استجابة للوضع الحالي للسوق.