### PR TITLE
Fix: Use virtual environment in deployment script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,13 +1,33 @@
 #!/bin/bash
 
-# Script to gracefully stop, update, and restart the Telegram analysis bot.
+# Script to gracefully stop, update, and restart the Telegram analysis bot
+# using a Python virtual environment.
 
 BOT_PROCESS_NAME="python main.py"
 LOG_FILE="bot.log"
+VENV_DIR="venv"
 
-echo ">>> 1. Attempting to stop any existing bot process..."
+echo ">>> 1. Checking for Virtual Environment..."
+if [ ! -d "$VENV_DIR" ]; then
+    echo "    - Virtual environment not found. Creating one at '$VENV_DIR/'..."
+    python3 -m venv $VENV_DIR
+    if [ $? -ne 0 ]; then
+        echo "    - ERROR: Failed to create virtual environment. Please ensure 'python3-venv' is installed."
+        exit 1
+    fi
+    echo "    - Virtual environment created successfully."
+else
+    echo "    - Virtual environment found."
+fi
+
+# Define paths to python and pip within the venv
+PYTHON_EXEC="$VENV_DIR/bin/python"
+PIP_EXEC="$VENV_DIR/bin/pip"
+
+echo ">>> 2. Attempting to stop any existing bot process..."
 # Find the process ID (PID) of the bot. The `grep -v grep` part is to exclude the grep process itself.
-PID=$(ps aux | grep "$BOT_PROCESS_NAME" | grep -v grep | awk '{print $2}')
+# We also look for the venv path to be more specific.
+PID=$(ps aux | grep "$VENV_DIR/bin/python main.py" | grep -v grep | awk '{print $2}')
 
 if [ -n "$PID" ]; then
     echo "    - Bot process found with PID: $PID. Stopping it now."
@@ -19,16 +39,16 @@ else
     echo "    - No running bot process found. Continuing."
 fi
 
-echo ">>> 2. Pulling latest changes from Git..."
+echo ">>> 3. Pulling latest changes from Git..."
 git pull
 
-echo ">>> 3. Installing/Updating dependencies from requirements.txt..."
-pip install -r requirements.txt
+echo ">>> 4. Installing/Updating dependencies into the virtual environment..."
+$PIP_EXEC install -r requirements.txt
 
-echo ">>> 4. Starting the bot in the background..."
+echo ">>> 5. Starting the bot in the background using the virtual environment..."
 # Use nohup to keep the process running after the terminal is closed.
 # Redirect stdout and stderr to a log file.
-nohup python main.py > $LOG_FILE 2>&1 &
+nohup $PYTHON_EXEC main.py > $LOG_FILE 2>&1 &
 
 echo ">>> Bot has been started successfully."
 echo ">>> You can view the logs by running: tail -f $LOG_FILE"


### PR DESCRIPTION
Updates `start.sh` to create and use a Python virtual environment (`venv`). This resolves the `externally-managed-environment` error encountered on Debian-based systems, which prevents `pip` from installing packages globally.

The script now:
- Checks for the existence of a `venv` directory.
- Creates the `venv` if it doesn't exist.
- Uses the `pip` and `python` executables from within the `venv` to install dependencies and run the bot.