### PR TITLE
تحسين جلب البيانات وإصلاح حساب الثقة

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -25,7 +25,7 @@ class AppSettings(BaseSettings):
     TIMEFRAME_HIERARCHY: Dict[str, str] = {
         '3m': '15m', '5m': '30m', '15m': '1H', '30m': '4H', '1H': '4H', '4H': '1D'
     }
-    CANDLE_FETCH_LIMITS: Dict[str, int] = {"default": 1000, "1D": 360}
+    CANDLE_FETCH_LIMITS: Dict[str, int] = {"default": 3000, "4h": 1000, "1D": 360}
     ANALYSIS_INTERVAL_MINUTES: int = 15
     TRADE_AMOUNT: str = "0.001"
 


### PR DESCRIPTION
- تعديل `populate_data.py` لاستخدام `CANDLE_FETCH_LIMITS` من الإعدادات، مما يسمح بجلب عدد متغير من الشموع (مثل 3000 أو 360) بدلاً من قيمة ثابتة (1000).
- تحديث `src/settings.py` لتعيين حدود الشموع المطلوبة.
- إصلاح فشل الاختبارات في `fibo_analyzer.py` عن طريق تعديل حساب "درجة الثقة" لتعكس بشكل صحيح تأثير توافق أو تعارض الاتجاهات مع الإطارات الزمنية الأعلى.