### PR TITLE
إصلاح: معالجة خطأ التايم أوت في تيليجرام وتحسين إعدادات جلب البيانات

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -25,7 +25,15 @@ class AppSettings(BaseSettings):
     TIMEFRAME_HIERARCHY: Dict[str, str] = {
         '3m': '15m', '5m': '30m', '15m': '1H', '30m': '4H', '1H': '4H', '4H': '1D'
     }
-    CANDLE_FETCH_LIMITS: Dict[str, int] = {"default": 3000, "4h": 1000, "1D": 360}
+    CANDLE_FETCH_LIMITS: Dict[str, int] = {
+        "default": 3000,
+        "1D": 360,
+        "4h": 1000,
+        "1h": 3000,
+        "30m": 3000,
+        "15m": 3000,
+        "5m": 3000
+    }
     ANALYSIS_INTERVAL_MINUTES: int = 15
     TRADE_AMOUNT: str = "0.001"
 

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -2,6 +2,7 @@ import logging
 import asyncio
 from datetime import datetime
 from telegram import Update, InlineKeyboardMarkup, InlineKeyboardButton
+from telegram.error import BadRequest
 from telegram.constants import ParseMode
 from telegram.ext import (
     Application,
@@ -52,7 +53,12 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     # Simplified send/edit logic without parse modes.
     if update.callback_query:
-        await update.callback_query.answer()
+        try:
+            await update.callback_query.answer()
+        except BadRequest as e:
+            # Ignore "Query is too old" errors, which are expected after long analyses
+            if "Query is too old" not in str(e):
+                raise  # Re-raise other BadRequest errors
         await update.callback_query.edit_message_text(text=text, reply_markup=reply_markup)
     else:
         await update.message.reply_text(text=text, reply_markup=reply_markup)


### PR DESCRIPTION
- **إصلاح خطأ `BadRequest: Query is too old`**:
  - تم تعديل `src/telegram_bot.py` لمعالجة هذا الخطأ الذي كان يحدث عند استغراق عمليات التحليل وقتًا طويلاً.
  - تمت إضافة كتلة `try-except` حول `update.callback_query.answer()` لتجاهل الخطأ بأمان والسماح للبوت بإكمال عمله دون توقف.

- **تحسين إعدادات جلب البيانات**:
  - تم تحديث `src/settings.py` لجعل حدود جلب الشموع (`CANDLE_FETCH_LIMITS`) صريحة لكل إطار زمني.
  - هذا التعديل يضمن أن البوت يطلب دائمًا عددًا كافيًا من الشموع للتحليل، مما يقلل من ظهور تحذيرات `InsufficientDataError`.

- **توضيح بخصوص قاعدة البيانات**:
  - تم التأكيد من خلال تحليل الكود أن البوت لا يستخدم قاعدة بيانات SQLite، وأن الخطأ المتعلق بها كان ناتجًا عن استعلام يدوي. لم يتم إجراء أي تغييرات على هذا الصعيد لأنها غير ضرورية.