### PR TITLE
feat: Implement local data caching and apply fixes

### DIFF
--- a/src/data_retrieval/data_fetcher.py
+++ b/src/data_retrieval/data_fetcher.py
@@ -27,7 +27,7 @@ class DataFetcher:
             debug=self.debug
         )
 
-    def fetch_historical_data(self, symbol: str, timeframe: str, limit: int = 300) -> Dict:
+    def fetch_historical_data(self, symbol: str, timeframe: str, limit: int = 1000) -> Dict:
         """
         Fetches historical candlestick data for a given symbol and timeframe.
 
@@ -46,12 +46,9 @@ class DataFetcher:
         # Convert symbol to API-compatible format (e.g., BTC/USDT -> BTC-USDT)
         api_symbol = symbol.replace('/', '-')
 
-        # OKX API expects uppercase 'H' for hour timeframes.
-        # This ensures '1h' becomes '1H', '4h' becomes '4H', etc., while leaving '30m' unaffected.
-        if 'h' in timeframe and 'm' not in timeframe:
-            api_timeframe = timeframe.upper()
-        else:
-            api_timeframe = timeframe
+        # OKX API expects specific capitalization (e.g., 1H, 4H, 1D).
+        # This makes the conversion more robust.
+        api_timeframe = timeframe.replace('h', 'H').replace('d', 'D')
 
         logger.info(f"Fetching {limit} historical data for {symbol} on {timeframe} (API symbol: {api_symbol}, API timeframe: {api_timeframe})...")
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -26,13 +26,8 @@ class AppSettings(BaseSettings):
         '3m': '15m', '5m': '30m', '15m': '1H', '30m': '4H', '1H': '4H', '4H': '1D'
     }
     CANDLE_FETCH_LIMITS: Dict[str, int] = {
-        "default": 3000,
-        "1D": 360,
-        "4h": 1000,
-        "1h": 3000,
-        "30m": 3000,
-        "15m": 3000,
-        "5m": 3000
+        "default": 1000,
+        "1D": 360
     }
     ANALYSIS_INTERVAL_MINUTES: int = 15
     TRADE_AMOUNT: str = "0.001"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,8 +16,8 @@ async def test_btc_1d_analysis_runs_successfully(mock_config, mock_fetcher):
     # with the data fetched from the exchange for the 1D timeframe.
     analyzer = FiboAnalyzer(mock_config, mock_fetcher, timeframe=timeframe)
 
-    # Fetch the data
-    df = await _fetch_and_prepare_data(mock_fetcher, symbol, timeframe, limit=300)
+    # Fetch the data, passing the config dictionary as required
+    df = await _fetch_and_prepare_data(mock_config, symbol, timeframe, limit=300)
 
     # We now expect the analysis to complete without any errors.
     analysis_result = analyzer.get_analysis(df, symbol, timeframe)


### PR DESCRIPTION
This commit introduces a local caching mechanism to reduce API calls and improve performance. The bot now attempts to load data from local JSON files before falling back to the OKX API.

Key changes:
- Modified `telegram_bot.py` to implement the "local file first, API fallback" strategy.
- Unified the handling of currency pair formats (e.g., 'BTC/USDT' and 'BTC-USDT').
- Adjusted `settings.py` to set candle fetch limits to 1000 by default and 360 for the '1D' timeframe.
- Updated `data_fetcher.py` to be more robust in handling timeframe strings.
- Fixed integration tests to align with the new data fetching function signature.